### PR TITLE
Ext4Pkg: Fix CRC16 checksumming on block groups

### DIFF
--- a/Features/Ext4Pkg/Ext4Dxe/BlockGroup.c
+++ b/Features/Ext4Pkg/Ext4Dxe/BlockGroup.c
@@ -169,14 +169,10 @@ Ext4CalculateBlockGroupDescChecksumGdtCsum (
   )
 {
   UINT16  Csum;
-  UINT16  Dummy;
 
-  Dummy = 0;
-
-  Csum = CalculateCrc16Ansi (Partition->SuperBlock.s_uuid, 16, 0);
+  Csum = CalculateCrc16Ansi (Partition->SuperBlock.s_uuid, 16, CRC16ANSI_INIT);
   Csum = CalculateCrc16Ansi (&BlockGroupNum, sizeof (BlockGroupNum), Csum);
   Csum = CalculateCrc16Ansi (BlockGroupDesc, OFFSET_OF (EXT4_BLOCK_GROUP_DESC, bg_checksum), Csum);
-  Csum = CalculateCrc16Ansi (&Dummy, sizeof (Dummy), Csum);
   Csum =
     CalculateCrc16Ansi (
       &BlockGroupDesc->bg_block_bitmap_hi,


### PR DESCRIPTION
Old filesystems (around 2008 and older) do not use CRC32c but rather CRC16-ANSI. Previously, the CalculateCrc16Ansi function was broken and gave us wrong checksums. Adapt to the new interface.

And while we're at it, fix the checksum algorithm itself - the crc16 algorithm just skips over the bg_checksum, and does not checksum it.

This problem was found out-of-list when older ext4 filesystems (that use crc16 checksums) failed to mount with "corruption".

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4609

Cc: Savva Mitrofanov <savvamtr@gmail.com>
Cc: Marvin Häuser <mhaeuser@posteo.de>